### PR TITLE
Add quotes around password

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -20,7 +20,7 @@ if [[ ! $? -eq 0 ]]; then
 fi
 
 # 'password' must be >= 8 characters
-if [[ $(expr length $password) -lt "8" ]]; then
+if [[ $(expr length "$password") -lt "8" ]]; then
     echo "Error : the password must be >= 8 characters"
     exit 1
 fi


### PR DESCRIPTION
Hi there,

I failed to install Ghost because I used a password with spaces (see this [xkcd](https://www.xkcd.com/936/), it's valid security-wise).
This patch fixes that.

I also noticed that my password appears in clear in the installation logs:
![image](https://user-images.githubusercontent.com/371705/32382440-7f90c5ca-c0b5-11e7-934c-dd7427c1f238.png)

Is it also possible (I mean feasible) to fix that?

Cheers!
Florent