### PR TITLE
[fix] Systemd service

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -8,7 +8,8 @@ WorkingDirectory=__FINALPATH__
 User=__APP__
 Group=__APP__
 Environment="NODE_ENV=production"
-ExecStart=/usr/bin/node index.js run
+Environment="PATH=__ENV_PATH__"
+ExecStart=__NODE__/node index.js run
 Restart=always
 
 [Install]


### PR DESCRIPTION
## Problem

The service does not work properly because the specified node version is not the correct one.

## Solution
Use the path provided by the node helper. https://github.com/YunoHost/yunohost/blob/stretch-unstable/data/helpers.d/nodejs#L31-L35

fixes #12 and #13