### PR TITLE
Fix wrong nodejs path

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -8,7 +8,7 @@ WorkingDirectory=__FINALPATH__
 User=__APP__
 Group=__APP__
 Environment="NODE_ENV=production"
-ExecStart=/usr/bin/node index.js run
+ExecStart=__NODEJS_PATH__/node index.js run
 Restart=always
 
 [Install]

--- a/scripts/install
+++ b/scripts/install
@@ -74,6 +74,7 @@ ynh_app_setting_set $app port $port
 
 # install nodejs
 ynh_install_nodejs 8
+ynh_use_nodejs
 
 # add yarn repo for Debian
 curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
@@ -174,6 +175,7 @@ chown -R $app: $final_path
 #=================================================
 
 # Create a dedicated systemd config
+ynh_replace_string --match_string="__NODEJS_PATH__" --replace_string="$nodejs_path" --target_file="../conf/systemd.service"
 ynh_add_systemd_config
 systemctl start "$app"
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -82,6 +82,7 @@ chown -R $app: $final_path
 
 # install nodejs
 ynh_install_nodejs 8
+ynh_use_nodejs
 
 # add yarn repo for Debian
 curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -


### PR DESCRIPTION
The systemd service does not work properly because the specified node path /usr/bin/node is not the correct.

My solution:
I added `ynh_use_nodejs` to fetch `$nodejs_path` and write to the systemd.service