### PR TITLE
Add warning to example url path

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -39,7 +39,7 @@
                     "en": "Choose a path for Ghost",
                     "fr": "Choisissez un chemin pour Ghost"
                 },
-                "example": "/blog",
+                "example": "/blog (do not use /ghost)",
                 "default": "/blog"
             },
             {


### PR DESCRIPTION
## Problem
Some people might use `/ghost` url path. This will break the admin portal

## Solution
Add a warning to the example URL

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/ghost_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/ghost_ynh%20PR-NUM-%20(USERNAME)/)  
