### PR TITLE
Appease linter

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -31,12 +31,11 @@
         "install" : [
             {
                 "name": "domain",
-                "type": "domain",
-                "example": "domain.org"
+                "type": "domain"
             },
             {
                 "name": "path",
-                "type": "path", 
+                "type": "path",
                 "example": "/blog",
                 "default": "/blog"
             },

--- a/scripts/install
+++ b/scripts/install
@@ -129,12 +129,12 @@ ynh_script_progression --message="Building $app... (this will take some time and
 pushd "$final_path" || ynh_die
 
 	ynh_use_nodejs
-	yarn install --non-interactive --silent
-	yarn global add knex-migrator
-	NODE_ENV=production knex-migrator init
-	yarn global add grunt-cli ember-cli
-	NODE_ENV=production grunt symlink
-	NODE_ENV=production grunt init --force
+	ynh_exec_warn_less yarn install --non-interactive --silent
+	ynh_exec_warn_less yarn global add knex-migrator
+	ynh_exec_warn_less NODE_ENV=production knex-migrator init
+	ynh_exec_warn_less yarn global add grunt-cli ember-cli
+	ynh_exec_warn_less NODE_ENV=production grunt symlink
+	ynh_exec_warn_less NODE_ENV=production grunt init --force
 
 popd || ynh_die
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -39,8 +39,6 @@ port=$(ynh_app_setting_get --app=$app --key=port)
 #=================================================
 ynh_script_progression --message="Validating restoration parameters..."
 
-ynh_webpath_available --domain=$domain --path_url=$path_url \
-	|| ynh_die --message="Path not available: ${domain}${path_url}"
 test ! -d $final_path \
 	|| ynh_die --message="There is already a directory: $final_path "
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -156,12 +156,12 @@ then
 	ynh_script_progression --message="Building $app... (this will take some time and resources!)"
 
 	pushd "$final_path" || ynh_die
-		yarn install
-		yarn global add knex-migrator
-		NODE_ENV=production knex-migrator init
-		yarn global add grunt
-		NODE_ENV=production grunt symlink
-		NODE_ENV=production grunt init --force
+		ynh_exec_warn_less yarn install
+		ynh_exec_warn_less yarn global add knex-migrator
+		ynh_exec_warn_less NODE_ENV=production knex-migrator init
+		ynh_exec_warn_less yarn global add grunt
+		ynh_exec_warn_less NODE_ENV=production grunt symlink
+		ynh_exec_warn_less NODE_ENV=production grunt init --force
 
 	popd || ynh_die
 fi


### PR DESCRIPTION
## Problem

- Installation and upgrade logs are way too verbose during yarn builds.
- Linter has various warnings

## Solution

- `ynh_exec_warn_less` all the things
- Remove domain example in manifest
- Do not use ynh_webpath_available

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
