### PR TITLE
Fix Admin download in updater

### DIFF
--- a/.github/workflows/updater.sh
+++ b/.github/workflows/updater.sh
@@ -21,7 +21,7 @@ version=$(curl --silent "https://api.github.com/repos/$repo/releases" | jq -r '.
 assets=($(curl --silent "https://api.github.com/repos/$repo/releases" | jq -r '[ .[] | select(.tag_name=="'$version'").assets[].browser_download_url ] | join(" ") | @sh' | tr -d "'"))
 
 admin_repo="TryGhost/Admin"
-assets+=("https://api.github.com/repos/TryGhost/Admin/zipball/$version")
+assets+=("https://github.com/TryGhost/Admin/archive/refs/tags/${version}.zip")
 
 # Later down the script, we assume the version has only digits and dots
 # Sometimes the release name starts with a "v", so let's filter it out.


### PR DESCRIPTION
## Problem

#56 

## Solution

- Fix Admin package download url

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
