### PR TITLE
Fix typo in a comment

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -91,7 +91,7 @@ then
 	# Create a temporary directory
 	tmpdir="$(mktemp -d)"
 
-	# Copy the admin saved settings from tmp directory to final path
+	# Copy the admin saved settings from final path to tmp directory
 	cp -ar "$final_path/config.production.json" "$tmpdir/config.production.json"
 
 	# Backup the content folder to the temp dir


### PR DESCRIPTION
## Problem

- *I was reading the upgrade script and saw a typo/mistake in a comment: bad direction for describing a cp command*

## Solution

- *I reversed the direction.*

## PR Status

- [x] Code finished and ready to be reviewed/tested

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
