### PR TITLE
Reenable RestrictAddressFamilies safety setting

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -17,8 +17,7 @@ Restart=always
 NoNewPrivileges=yes
 PrivateTmp=yes
 PrivateDevices=yes
-#RestrictAddressFamilies disabled, prevents any write access on the app
-#RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
 RestrictNamespaces=yes
 RestrictRealtime=yes
 DevicePolicy=closed


### PR DESCRIPTION
The addition of AF_NETLINK should be enough for it to work, without allowing the dozen of other families.

## Problem

We had an issue with kresus failing to start with:
```
node:os:68
      throw new ERR_SYSTEM_ERROR(ctx);
      ^
SystemError [ERR_SYSTEM_ERROR]: A system error occurred: uv_interface_addresses returned Unknown system error 97 (Unknown system error 97)
    at Object.networkInterfaces (node:os:259:16)
    at Object.<anonymous> (/usr/lib/kresus/node_modules/nodemailer/lib/shared/index.js:15:66)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/usr/lib/kresus/node_modules/nodemailer/lib/mailer/index.js:4:16)
    at Module._compile (node:internal/modules/cjs/loader:1105:14) {
  code: 'ERR_SYSTEM_ERROR',
  info: {
    errno: 97,
    code: 'Unknown system error 97',
    message: 'Unknown system error 97',
    syscall: 'uv_interface_addresses'
  },
  errno: [Getter/Setter],
  syscall: [Getter/Setter]
}
```
Searching for `A system error occurred: uv_interface_addresses returned Unknown system error 97 (Unknown system error 97)` lead us to https://forum.yunohost.org/t/ghost-4-20-3-ynh1-broke-all-editing-fixed/17629 and then here.

Allowing all families wasn’t a good idea for us, so we looked for a solution.

## Solution

It appears that recent version make a call to https://nodejs.org/api/os.html#osnetworkinterfaces, which requires `AF_NETLINK`. This should be enough, but as I don’t use ghost nor yunohost, I haven’t tested it. However it works for kresus.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
