### PR TITLE
Update to v5.8.3 and use new install format

### DIFF
--- a/conf/admin.src
+++ b/conf/admin.src
@@ -1,5 +1,0 @@
-SOURCE_URL=https://github.com/TryGhost/Admin/archive/refs/tags/v5.3.1.zip
-SOURCE_SUM=e877de2f2d1c262e4fc284bf419fe75a72ad0640412a8eb0dcbc7b5721abef88
-SOURCE_SUM_PRG=sha256sum
-SOURCE_FORMAT=zip
-SOURCE_IN_SUBDIR=true

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://api.github.com/repos/TryGhost/Ghost/zipball/v5.2.4
-SOURCE_SUM=04ba64fd6f7ecb0ba0970eb63189b5b5780095260bce5d4edd2b50e25d0a316b
+SOURCE_URL=https://api.github.com/repos/TryGhost/Ghost/zipball/v5.8.3
+SOURCE_SUM=557c39864483fff00beeb60e27d84915e184845c69db3be83dcd7a65f327d497
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=true

--- a/conf/casper.src
+++ b/conf/casper.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/TryGhost/Casper/archive/refs/tags/v5.1.5.zip
-SOURCE_SUM=ad883bf9e3ded051b21e4f2473cbcf32bdacdd8258f29bc45c4fdc0e3fc3e57f
+SOURCE_URL=https://github.com/TryGhost/Casper/archive/refs/tags/v5.2.3.zip
+SOURCE_SUM=49d57ce078a2775f39d019ed74fa4ae9476e95fa35b02593c726c0ea25fe49df
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=true

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -9,7 +9,8 @@ Group=__APP__
 WorkingDirectory=__FINALPATH__
 Environment="__YNH_NODE_LOAD_PATH__"
 Environment="NODE_ENV=production"
-ExecStart=__YNH_NODE__ index.js run
+#ExecStart=__YNH_NODE__ core/index.js run
+ExecStart=yarn start
 Restart=always
 
 # Sandboxing options to harden security

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Publishing, memberships, subscriptions and newsletters platform",
         "fr": "Plateforme d'édition, d'adhésions, d'abonnements et de newsletters"
     },
-    "version": "5.3.1~ynh1",
+    "version": "5.8.3~ynh1",
     "url": "https://ghost.org/",
     "upstream": {
         "license": "MIT",

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -124,9 +124,9 @@ fi
 #=================================================
 ynh_script_progression --message="Modifying a config file..."
 
-ynh_add_config --template="../conf/config.production.json" --destination="$final_path/config.production.json"
-chmod 400 "$final_path/config.production.json"
-chown $app:$app "$final_path/config.production.json"
+ynh_add_config --template="../conf/config.production.json" --destination="$final_path/ghost/core/config.production.json"
+chmod 400 "$final_path/ghost/core/config.production.json"
+chown $app:$app "$final_path/ghost/core/config.production.json"
 
 #=================================================
 # GENERIC FINALISATION

--- a/scripts/install
+++ b/scripts/install
@@ -99,13 +99,9 @@ ynh_app_setting_set --app=$app --key=final_path --value=$final_path
 # Download, check integrity, uncompress and patch the source from app.src
 ynh_setup_source --dest_dir="$final_path"
 
-# Download, check integrity, uncompress and patch the source from admin.src
-mkdir -p $final_path/core/client/Admin
-ynh_setup_source --dest_dir="$final_path/core/admin" --source_id="admin"
-
 # Download, check integrity, uncompress and patch the source from casper.src
-mkdir -p $final_path/content/themes/casper
-ynh_setup_source --dest_dir="$final_path/content/themes/casper" --source_id="casper"
+mkdir -p $final_path/ghost/core/content/themes/casper
+ynh_setup_source --dest_dir="$final_path/ghost/core/content/themes/casper" --source_id="casper"
 
 chmod 750 "$final_path"
 chmod -R o-rwx "$final_path"
@@ -126,9 +122,9 @@ ynh_add_nginx_config
 #=================================================
 ynh_script_progression --message="Modifying a config file..."
 
-ynh_add_config --template="../conf/config.production.json" --destination="$final_path/config.production.json"
-chmod 400 "$final_path/config.production.json"
-chown $app:$app "$final_path/config.production.json"
+ynh_add_config --template="../conf/config.production.json" --destination="$final_path/ghost/core/config.production.json"
+chmod 400 "$final_path/ghost/core/config.production.json"
+chown $app:$app "$final_path/ghost/core/config.production.json"
 
 #==============================================
 # BUILD GHOST
@@ -137,11 +133,8 @@ ynh_script_progression --message="Building Ghost... (this will take some time an
 
 pushd "$final_path"
 	ynh_use_nodejs
-	ynh_exec_warn_less ynh_exec_as $app $ynh_node_load_PATH yarn install --non-interactive
-	ynh_exec_warn_less ynh_exec_as $app $ynh_node_load_PATH yarn add knex-migrator
-	ynh_exec_warn_less ynh_exec_as $app $ynh_node_load_PATH $final_path/node_modules/.bin/knex-migrator init
-	ynh_exec_warn_less ynh_exec_as $app $ynh_node_load_PATH $final_path/node_modules/.bin/grunt symlink
-	ynh_exec_warn_less ynh_exec_as $app $ynh_node_load_PATH $final_path/node_modules/.bin/grunt init --force
+	ynh_exec_warn_less ynh_exec_as $app $ynh_node_load_PATH yarn add knex-migrator ember-cli --dev --ignore-workspace-root-check --non-interactive
+	ynh_exec_warn_less ynh_exec_as $app $ynh_node_load_PATH yarn setup # catch-all command provided by Ghost that handles all the setup
 popd
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -133,6 +133,8 @@ ynh_script_progression --message="Building Ghost... (this will take some time an
 
 pushd "$final_path"
 	ynh_use_nodejs
+	# Longer network timeouts for slow systems; see https://github.com/yarnpkg/yarn/issues/8242
+	ynh_exec_warn_less ynh_exec_as $app $ynh_node_load_PATH yarn config set network-timeout 600000
 	ynh_exec_warn_less ynh_exec_as $app $ynh_node_load_PATH yarn add knex-migrator ember-cli --dev --ignore-workspace-root-check --non-interactive
 	ynh_exec_warn_less ynh_exec_as $app $ynh_node_load_PATH yarn setup # catch-all command provided by Ghost that handles all the setup
 popd

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -176,6 +176,8 @@ then
 	ynh_script_progression --message="Building Ghost... (this will take some time and resources!)"
 
 	pushd "$final_path"
+		# Longer network timeouts for slow systems; see https://github.com/yarnpkg/yarn/issues/8242
+		ynh_exec_warn_less ynh_exec_as $app $ynh_node_load_PATH yarn config set network-timeout 600000
 		ynh_exec_warn_less ynh_exec_as $app $ynh_node_load_PATH yarn install --non-interactive
 		ynh_exec_warn_less ynh_exec_as $app $ynh_node_load_PATH yarn add knex-migrator ember-cli --dev --ignore-workspace-root-check --non-interactive
 		ynh_exec_warn_less ynh_exec_as $app $ynh_node_load_PATH yarn setup

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -92,7 +92,7 @@ then
 	tmpdir="$(mktemp -d)"
 
 	# Copy the admin saved settings from final path to tmp directory
-	if [ -d "$final_path/config.production.json" ]
+	if [ -f "$final_path/config.production.json" ]
 	then
 		# Old versions of Ghost store it here
 		cp -ar "$final_path/config.production.json" "$tmpdir/config.production.json"
@@ -102,7 +102,7 @@ then
 	fi
 
 	# Backup the content folder to the temp dir
-	if [ -d "$final_path/config.production.json" ]
+	if [ -f "$final_path/config.production.json" ]
 	then
 		# Old versions of Ghost store it here
 		cp -ar "$final_path/content" "$tmpdir/content"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -92,10 +92,24 @@ then
 	tmpdir="$(mktemp -d)"
 
 	# Copy the admin saved settings from final path to tmp directory
-	cp -ar "$final_path/config.production.json" "$tmpdir/config.production.json"
+	if [ -d "$final_path/config.production.json" ]
+	then
+		# Old versions of Ghost store it here
+		cp -ar "$final_path/config.production.json" "$tmpdir/config.production.json"
+	else
+		# New versions of Ghost store it here
+		cp -ar "$final_path/ghost/core/config.production.json" "$tmpdir/config.production.json"
+	fi
 
 	# Backup the content folder to the temp dir
-	cp -ar "$final_path/content" "$tmpdir/content"
+	if [ -d "$final_path/config.production.json" ]
+	then
+		# Old versions of Ghost store it here
+		cp -ar "$final_path/content" "$tmpdir/content"
+	else
+		# New versions of Ghost store it here
+		cp -ar "$final_path/ghost/core/content" "$tmpdir/content"
+	fi
 
 	# Remove the app directory securely
 	ynh_secure_remove --file=$final_path
@@ -103,19 +117,15 @@ then
 	# Download, check integrity, uncompress and patch the source from app.src
 	ynh_setup_source --dest_dir=$final_path
 
-	# Download, check integrity, uncompress and patch the source from admin.src
-	mkdir -p $final_path/core/client/Admin
-	ynh_setup_source --dest_dir="$final_path/core/admin" --source_id="admin"
-
 	# Download, check integrity, uncompress and patch the source from casper.src
 	mkdir -p $final_path/content/themes/casper
-	ynh_setup_source --dest_dir="$final_path/content/themes/casper" --source_id="casper"
+	ynh_setup_source --dest_dir="$final_path/ghost/core/content/themes/casper" --source_id="casper"
 
 	# Copy the admin saved settings from tmp directory to final path
-	cp -ar "$tmpdir/config.production.json" "$final_path/config.production.json"
+	cp -ar "$tmpdir/config.production.json" "$final_path/ghost/core/config.production.json"
 
 	# Copy content folder back to the final_path
-	cp -ar "$tmpdir/content" "${final_path}"
+	cp -ar "$tmpdir/content" "${final_path}/ghost/core"
 
 	# Remove the tmp directory securely
 	ynh_secure_remove --file="$tmpdir"
@@ -153,9 +163,9 @@ ynh_install_extra_app_dependencies --repo="deb https://dl.yarnpkg.com/debian/ st
 #=================================================
 ynh_script_progression --message="Modifying a config file..."
 
-ynh_add_config --template="../conf/config.production.json" --destination="$final_path/config.production.json"
-chmod 400 "$final_path/config.production.json"
-chown $app:$app "$final_path/config.production.json"
+ynh_add_config --template="../conf/config.production.json" --destination="$final_path/ghost/core/config.production.json"
+chmod 400 "$final_path/ghost/core/config.production.json"
+chown $app:$app "$final_path/ghost/core/config.production.json"
 
 #==============================================
 # BUILD GHOST
@@ -167,10 +177,8 @@ then
 
 	pushd "$final_path"
 		ynh_exec_warn_less ynh_exec_as $app $ynh_node_load_PATH yarn install --non-interactive
-		ynh_exec_warn_less ynh_exec_as $app $ynh_node_load_PATH yarn add knex-migrator
-		ynh_exec_warn_less ynh_exec_as $app $ynh_node_load_PATH $final_path/node_modules/.bin/knex-migrator init
-		ynh_exec_warn_less ynh_exec_as $app $ynh_node_load_PATH $final_path/node_modules/.bin/grunt symlink
-		ynh_exec_warn_less ynh_exec_as $app $ynh_node_load_PATH $final_path/node_modules/.bin/grunt init --force
+		ynh_exec_warn_less ynh_exec_as $app $ynh_node_load_PATH yarn add knex-migrator ember-cli --dev --ignore-workspace-root-check --non-interactive
+		ynh_exec_warn_less ynh_exec_as $app $ynh_node_load_PATH yarn setup
 	popd
 fi
 


### PR DESCRIPTION
## Problem

Ghost has significantly changed their file structure, which means the earlier build process was broken and the scripts had to be changed around quite a bit. (This commit builds upon the work by @tituspijean in #164)

~~:warning: **The upgrade process is completely untested!** Don't upgrade to this version unless you know what you are doing.~~ **update:** I've manually tested the update process now and it seems to be working :grin:

## Solution

Significant changes for the new build process are:

  - Config and content now lives under ./ghost/core instead of being directly in the project root. While updating, for
    backward compatibility, we need to check for the existence of the old folder as well
  - The admin interface is bundled along with the main Ghost package, so there is no need to download it separately (Casper is still being downloaded separately though)
  - Using `yarn setup` because manually running knex, grunt, etc. was causing problems (`yarn setup` automatically calls those commands for us behind the scenes)
 - Similarly, we are now running `yarn start` to execute the Ghost process in the systemd config, instead of manually running index.js` as we were doing earlier.

I think that sums up all the changes. Hopefully nothing else crops up!

## PR Status

- [x] Code finished and ready to be reviewed/tested
  - [x] Changing the config and content location
  - [x] No separate download of the admin interface
  - [x] Successful build process
  - [x] Successful start after Ghost installed
- [x] The fix/enhancement were manually tested (if applicable)
  - [x] Successful fresh installation
    - [x] Homepage loading after installation
    - [x] Admin loading after installation (comes to welcome screen)
    - [x] More in-depth testing of admin (try creating a post, etc.)
  - [x] Upgrade from legacy version (eg. `v4.x`)
  - [x] Upgrade from latest master (the flawed `v5.2.2` at 4795e83d27083a0ad3970f5f99425db71148514d)
  - [x] Backup and restore

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
