### PR TITLE
Remove antifeatures from the manifest.toml

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -16,9 +16,6 @@ code = "https://github.com/TryGhost/Ghost"
 cpe = "cpe:2.3:a:ghost:ghost"
 fund = "https://opencollective.com/ghost"
 
-[antifeatures]
-arbitrary-limitations.en = "Ghost developers have chosen to only support MySQL. YunoHost relying on MariaDB, incompatibilities may arise. For more information: https://github.com/TryGhost/Ghost/issues/15729#issuecomment-1299297720"
-
 [integration]
 yunohost = ">= 11.2"
 architectures = "all"


### PR DESCRIPTION
This is not (yet?) supported. It should go into the DESCRIPTION.md or equivalent.
