### PR TITLE
Upgrade to v5.116.2

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Ghost"
 description.en = "Publishing, memberships, subscriptions and newsletters platform"
 description.fr = "Plateforme d'édition, d'adhésions, d'abonnements et de newsletters"
 
-version = "5.116.1~ynh1"
+version = "5.116.2~ynh1"
 maintainers = []
 
 [upstream]
@@ -49,8 +49,8 @@ ram.runtime = "1G"
     [resources.sources.main]
     # Unused source, only to trigger the autoupdater
     prefetch = false
-    url = "https://github.com/TryGhost/Ghost/archive/refs/tags/v5.116.1.tar.gz"
-    sha256 = "be445e3f9dfe465d3d2e57d58c89cf2a5a81d027f5ebc3057c0a9bd8faa906ea"
+    url = "https://github.com/TryGhost/Ghost/archive/refs/tags/v5.116.2.tar.gz"
+    sha256 = "1e390eaf31f54ab7f6fe3c0474831aabdd37f320a5b66619421191acc074503a"
     autoupdate.strategy = "latest_github_release"
 
     [resources.system_user]

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Ghost"
 description.en = "Publishing, memberships, subscriptions and newsletters platform"
 description.fr = "Plateforme d'édition, d'adhésions, d'abonnements et de newsletters"
 
-version = "5.116.0~ynh1"
+version = "5.116.1~ynh1"
 maintainers = []
 
 [upstream]
@@ -49,8 +49,8 @@ ram.runtime = "1G"
     [resources.sources.main]
     # Unused source, only to trigger the autoupdater
     prefetch = false
-    url = "https://github.com/TryGhost/Ghost/archive/refs/tags/v5.116.0.tar.gz"
-    sha256 = "d0f3d8d7efe6fa1542e2148ff03149757c2dc4b59f2b1f02d1590baff45e4347"
+    url = "https://github.com/TryGhost/Ghost/archive/refs/tags/v5.116.1.tar.gz"
+    sha256 = "be445e3f9dfe465d3d2e57d58c89cf2a5a81d027f5ebc3057c0a9bd8faa906ea"
     autoupdate.strategy = "latest_github_release"
 
     [resources.system_user]


### PR DESCRIPTION
Upgrade sources
- `main` v5.116.2: https://github.com/TryGhost/Ghost/releases/tag/v5.116.2

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
