### PR TITLE
chore: move from yarn to pnpm

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -71,11 +71,6 @@ ram.runtime = "1G"
     [resources.apt]
     packages = "mailutils, mariadb-server"
 
-    [resources.apt.extras.yarn]
-    repo = "deb https://dl.yarnpkg.com/debian/ stable main"
-    key = "https://dl.yarnpkg.com/debian/pubkey.gpg"
-    packages = ["yarn"]
-    
     [resources.database]
     type = "mysql"
 

--- a/scripts/install
+++ b/scripts/install
@@ -16,6 +16,7 @@ chown -R $app:$app "$install_dir"
 
 pushd $install_dir
 	ynh_script_progression "Installing and configuring $app..."
+	ynh_hide_warnings ynh_exec_as_app corepack enable pnpm
 	ynh_hide_warnings ynh_exec_as_app npm install npm@latest
 	ynh_hide_warnings ynh_exec_as_app npm install ghost-cli@latest
 	ynh_hide_warnings ynh_exec_as_app $install_dir/node_modules/.bin/ghost install $(ynh_app_upstream_version) \

--- a/scripts/install
+++ b/scripts/install
@@ -25,9 +25,6 @@ pushd $install_dir
 		--no-setup-nginx --no-setup-ssl --url https://$domain$path --port $port \
 		--db mysql --dbhost 127.0.0.1 --dbuser $db_user --dbpass $db_pwd --dbname $db_name \
 		--mail SMTP --mailhost 127.0.0.1 --mailport 465
-
-	# Cleanup cache
-	ynh_safe_rm ".cache/yarn"
 popd
 
 # Make sure the configuration is correct

--- a/scripts/install
+++ b/scripts/install
@@ -16,7 +16,7 @@ chown -R $app:$app "$install_dir"
 
 pushd $install_dir
 	ynh_script_progression "Installing and configuring $app..."
-	ynh_hide_warnings ynh_exec_as_app corepack enable pnpm
+	ynh_hide_warnings corepack enable && corepack prepare pnpm@latest --activate
 	ynh_hide_warnings ynh_exec_as_app npm install npm@latest
 	ynh_hide_warnings ynh_exec_as_app npm install ghost-cli@latest
 	ynh_hide_warnings ynh_exec_as_app $install_dir/node_modules/.bin/ghost install $(ynh_app_upstream_version) \

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -123,7 +123,9 @@ if [ ! -s "$config_file" ]; then
 fi
 
 # Cleanup cache
-ynh_safe_rm "$install_dir/.cache/yarn"
+pushd $install_dir
+	ynh_hide_warnings ynh_exec_as_app pnpm store prune
+popd
 
 #=================================================
 # REAPPLY SYSTEM CONFIGURATIONS

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -70,6 +70,7 @@ then
 	chown -R $app:$app "$install_dir"
 
 	pushd $install_dir
+		ynh_hide_warnings ynh_exec_as_app corepack enable pnpm
 		ynh_hide_warnings ynh_exec_as_app npm install npm@latest
 		ynh_hide_warnings ynh_exec_as_app npm install ghost-cli@latest
 		ynh_hide_warnings ynh_exec_as_app $install_dir/node_modules/.bin/ghost install $(ynh_app_upstream_version) \

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -70,7 +70,7 @@ then
 	chown -R $app:$app "$install_dir"
 
 	pushd $install_dir
-		ynh_hide_warnings ynh_exec_as_app corepack enable pnpm
+		ynh_hide_warnings corepack enable && corepack prepare pnpm@latest --activate
 		ynh_hide_warnings ynh_exec_as_app npm install npm@latest
 		ynh_hide_warnings ynh_exec_as_app npm install ghost-cli@latest
 		ynh_hide_warnings ynh_exec_as_app $install_dir/node_modules/.bin/ghost install $(ynh_app_upstream_version) \
@@ -91,6 +91,7 @@ else
 
 	# Upgrade Ghost CLI
 	pushd $install_dir
+		ynh_hide_warnings corepack enable && corepack prepare pnpm@latest --activate
 		ynh_hide_warnings ynh_exec_as_app npm install npm@latest
 		ynh_hide_warnings ynh_exec_as_app npm install ghost-cli@latest
 	popd


### PR DESCRIPTION
Upstream has replaced `yarn` with `pnpm`.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
