### PR TITLE
Fix systemd start wait_until 

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -61,7 +61,7 @@ yunohost service add $app --description="$app daemon for Ghost" --log="$install_
 #=================================================
 ynh_script_progression "Starting $app's systemd service..."
 
-ynh_systemctl --service=$app --action="start" --log_path="systemd" --wait_until="Ghost booted"
+ynh_systemctl --service=$app --action="start" --log_path="systemd" --wait_until="Ghost server started"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/restore
+++ b/scripts/restore
@@ -36,7 +36,7 @@ yunohost service add $app --description="$app daemon for Ghost" --log="$install_
 #=================================================
 ynh_script_progression "Reloading NGINX web server and $app's service..."
 
-ynh_systemctl --service=$app --action=start --log_path="systemd" --wait_until="Ghost booted" --timeout=60
+ynh_systemctl --service=$app --action=start --log_path="systemd" --wait_until="Ghost server started" --timeout=60
 
 ynh_systemctl --service=nginx --action=reload
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -146,7 +146,7 @@ yunohost service add $app --description="$app daemon for Ghost" --log="$install_
 #=================================================
 ynh_script_progression "Starting $app's systemd service..."
 
-ynh_systemctl --service=$app --action=start --log_path="systemd" --wait_until="Ghost server started" --timeout=60
+ynh_systemctl --service=$app --action=start --log_path="systemd" --wait_until="Ghost server started" --timeout=180
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -146,7 +146,7 @@ yunohost service add $app --description="$app daemon for Ghost" --log="$install_
 #=================================================
 ynh_script_progression "Starting $app's systemd service..."
 
-ynh_systemctl --service=$app --action=start --log_path="systemd" --wait_until="Ghost booted" --timeout=60
+ynh_systemctl --service=$app --action=start --log_path="systemd" --wait_until="Ghost server started" --timeout=60
 
 #=================================================
 # END OF SCRIPT


### PR DESCRIPTION
## Problem

- used to check `Ghost booted`

## Solution

- now check `Ghost server started
`
## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
